### PR TITLE
fix(detecto): handle inf in fit pot detecto

### DIFF
--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -173,7 +173,7 @@ class POTDetecto(Detecto):
                         anomaly_score=None,
                     )
                     anomaly_scores[f"anomaly_score_{feature_name}"].append(None)
-            anomaly_scores[f"total_anomaly_score"].append(total_anomaly_score_per_row)
+            anomaly_scores["total_anomaly_score"].append(total_anomaly_score_per_row)
         return DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, dataset: DataFrame):

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -127,7 +127,7 @@ class POTDetecto(Detecto):
         for row in range(0, t1_t2_exceedances.shape[0]):
             exceedances_for_learning = exceedance_dataset.iloc[: self.timeframe.t0 + row]  # type: ignore
             exceedances_of_interest = t1_t2_exceedances.iloc[[row]]
-            anomaly_score = 0.0
+            total_anomaly_score_per_row = 0.0
 
             for feature_name in t1_t2_exceedances.columns:
                 exceedances_for_fitting: list[float] = exceedances_for_learning[feature_name][
@@ -140,7 +140,7 @@ class POTDetecto(Detecto):
                             x=exceedances_of_interest[feature_name].iloc[0], c=c, loc=loc, scale=scale
                         )
                         inverted_p_value = 1 / p_value if p_value > 0.0 else float("inf")
-                        anomaly_score += inverted_p_value
+                        total_anomaly_score_per_row += inverted_p_value
                         self.set_params(
                             feature_name=feature_name,
                             row=row,
@@ -150,7 +150,7 @@ class POTDetecto(Detecto):
                             p_value=p_value,
                             anomaly_score=inverted_p_value,
                         )
-                        anomaly_scores[f"anomaly_score_{feature_name}"].append(anomaly_score)
+                        anomaly_scores[f"anomaly_score_{feature_name}"].append(inverted_p_value)
                     else:
                         self.set_params(
                             feature_name=feature_name,
@@ -173,6 +173,7 @@ class POTDetecto(Detecto):
                         anomaly_score=None,
                     )
                     anomaly_scores[f"anomaly_score_{feature_name}"].append(None)
+            anomaly_scores[f"total_anomaly_score"].append(total_anomaly_score_per_row)
         return DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, dataset: DataFrame):

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -18,15 +18,15 @@ class POTDetecto(Detecto):
         self.timeframe = POTTimeframe()
         self.__params = {}
 
-    def __set_params_structure(self, feature_names: list[str]) -> None:
+    def __set_params_structure(self, total_rows: int) -> None:
         """
         Initialize the parameter structure for storing model parameters.
 
         # Parameters
-            * feature_names (list[str]): The names of the features (columns) to initialize parameters for.
+            * feature_names (list[int]): A registry of GPD parameters and statistics per row index and feature.
         """
-        for feature_name in feature_names:
-            self.__params[feature_name] = []
+        for row in range(0, total_rows):
+            self.__params[row] = []
 
     @property
     def params(self) -> dict[str, list[dict[int, dict[str, float | None]]]]:
@@ -34,7 +34,7 @@ class POTDetecto(Detecto):
         Get the parameters set from model fitting.
 
         # Returns
-            * dict[Str, list[dict[int, dict[str, float | None]]]]: A dictionary containing the GPD fit parameters and statistics for each feature.
+            * dict[Str, list[dict[int, dict[str, float | None]]]]: A dictionary containing the GPD fit parameters and statistics for each row and feature.
         """
         return self.__params
 
@@ -50,13 +50,82 @@ class POTDetecto(Detecto):
                 * loc (float | None): The parameter that shifts the distribution along the horizontal axis and typically marks the threshold above which the tail begins.
                 * scale (float | None): The parameter that stretches or shrinks the distribution along the horizontal axis: Larger value shows the spread out of extreme values.
                 * p_value (float | None): The result from calculating the survival function, 1 - CDF, that determines the probability of observing an extreme value.
-                * inverted_p_value (float | None): The result from 1 / p-value to make smaller p-value large which reflects the extremness of the value.
-                * anomaly_score (float | None): The continuously accumulated inverted p-value per feature (column):
-                    * E.g. Feature 1 row 1, feature 1 row 1 + row 2, feature 1 row 1 + row 2 + ... + row n.
-        """
-        self.__params[kwargs.get("feature_name")].append(
+                * anomaly_score (float | None): The inverted p-value (1 / p-value) for each cell.
+                * total_anomaly_score (float): The accumulated inverted p-values per row.
+
+        # Example
+        A dataset with two columns and two rows:
+        ```json
             {
-                kwargs.get("row"): {
+                0: [
+                    {
+                        'col_1': {
+                            'gpd_params': {
+                                'c': None,
+                                'loc': None,
+                                'scale': None
+                                },
+                            'gpd_stats': {
+                                'anomaly_score': 0.0,
+                                'p_value': None
+                                }
+                        }
+                    },
+                    {
+                        'col_2': {
+                            'gpd_params': {
+                                'c': None,
+                                'loc': None,
+                                'scale': None
+                                },
+                            'gpd_stats': {
+                                'anomaly_score': 0.0,
+                                'p_value': None
+                                }
+                        }
+                    },
+                    {'total_anomaly_score': 0.0}
+                ],
+                1: [
+                    {
+                        'col_1': {
+                            'gpd_params': {
+                                'c': 5.942200541853957,
+                                'loc': 0,
+                                'scale': 76.50452706730246
+                                },
+                            'gpd_stats': {
+                                'anomaly_score': 1.4000018488279755,
+                                'p_value': 0.7142847710073806
+                                }
+                            }
+                        },
+                    {
+                        'col_2': {
+                            'gpd_params': {
+                                'c': None,
+                                'loc': None,
+                                'scale': None
+                                },
+                            'gpd_stats': {
+                                'anomaly_score': 0.0,
+                                'p_value': None
+                                }
+                        }
+                    },
+                    {
+                        'total_anomaly_score': 1.4000018488279755
+                    }
+                ],
+            }
+        ```
+        """
+        feature_name: str = kwargs.get("feature_name")  # type: ignore
+        data = (
+            {"total_anomaly_score": kwargs.get("total_anomaly_score_per_row")}
+            if feature_name == "total_anomaly_score"
+            else {
+                feature_name: {  # type: ignore
                     "gpd_params": {
                         "c": kwargs.get("c", None),
                         "loc": kwargs.get("loc", None),
@@ -64,12 +133,12 @@ class POTDetecto(Detecto):
                     },
                     "gpd_stats": {
                         "p_value": kwargs.get("p_value", None),
-                        "inverted_p_value": kwargs.get("inverted_p_value", None),
                         "anomaly_score": kwargs.get("anomaly_score", None),
                     },
                 }
             }
         )
+        self.__params[kwargs.get("row")].append(data)
 
     def compute_exceedance_threshold(self, dataset: DataFrame, q: float = 0.99) -> DataFrame:
         """
@@ -122,7 +191,7 @@ class POTDetecto(Detecto):
         anomaly_scores["total_anomaly_score"] = []
         t1_t2_exceedances = exceedance_dataset.iloc[self.timeframe.t0 :]  # type: ignore
 
-        self.__set_params_structure(feature_names=t1_t2_exceedances.columns)
+        self.__set_params_structure(total_rows=t1_t2_exceedances.shape[0])
 
         for row in range(0, t1_t2_exceedances.shape[0]):
             exceedances_for_learning = exceedance_dataset.iloc[: self.timeframe.t0 + row]  # type: ignore

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -125,7 +125,8 @@ class TestPOTDetecto(TestCase):
         expected_anomaly_score_df = DataFrame(
             data={
                 "anomaly_score_df_1_feature_1": [float("inf"), float("inf"), float("inf"), float("inf")],
-                "anomaly_score_df_1_feature_2": [float("inf"), None, float("inf"), float("inf")],
+                "anomaly_score_df_1_feature_2": [float("inf"), None, 1.2988597467759642, 2.129427676525411],
+                "total_anomaly_score": [float("inf"), float("inf"), float("inf"), float("inf")],
             }
         )
 

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -124,8 +124,8 @@ class TestPOTDetecto(TestCase):
         )
         expected_anomaly_score_df = DataFrame(
             data={
-                "anomaly_score_df_1_feature_1": [0.0, 0.0, 0.0, 0.0],
-                "anomaly_score_df_1_feature_2": [0.000000, 0.000000, 1.298860, 2.129428],
+                "anomaly_score_df_1_feature_1": [float("inf"), float("inf"), float("inf"), float("inf")],
+                "anomaly_score_df_1_feature_2": [float("inf"), None, float("inf"), float("inf")],
             }
         )
 


### PR DESCRIPTION
- [X] Param settings now take the row index for outer keys and column names (features) for inner keys.
- [X] Params now has a new structure `{row: {col: {...}}}`.
- [X] Super small or 0  p-value is treated as infinity.
- [X] Fit method returns a `DataFrame` with `total_anomaly_score` for total accumulated anomaly score per row + all other columns.