### PR TITLE
feat(models): create notification via email

### DIFF
--- a/src/detecto/models/notifications/email.py
+++ b/src/detecto/models/notifications/email.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+
+from detecto.models.notifications.interface import Notification
+
+
+class EmailNotification(Notification):
+    """
+    Notification class that setups the message for your anomalies and sends them via your email address.
+
+    # Attributes:
+        * sender_address (str): The email address from which the email will be sent.
+        * password (str): The password or app-specific password for authenticating the email account.
+        * recipient_addresses (list[str]): The list of your recipent's email addresses.
+        * smtp_server (str): The SMTP server address for the email provider: smtp.YOUR_EMAIL_PROVIDER.com.
+        * smtp_port (int): The SMTP server port for the email provider, default 587.
+        * __payload (str): The payload for the notification message, by default an empty string.
+        * __subject (str): The sibject of your email.
+    """
+
+    def __init__(
+        self,
+        sender_address: str,
+        password: str,
+        recipient_addresses: list[str],
+        smtp_server: str,
+        smtp_port: int = 587,
+    ) -> None:
+        self.sender_address = sender_address
+        self.password = password
+        self.smtp_server = smtp_server
+        self.smtp_port = smtp_port
+        self.recipient_addresses = recipient_addresses
+        self.__subject = "🤖 Detecto: Anomaly detected!"
+        self.__payload: str = ""
+
+    def __format_anomaly(self, anomaly: dict[str, str | float | int | datetime], index: int) -> str:  # type: ignore
+        """
+        Formats a single anomaly dictionary into a string for email message formatting.
+
+        Parameters:
+            anomaly (dict[str, str | float | int | datetime]): A dictionary containing details of an anomaly.
+            index (int): Index of the anomaly in the list, used for numbering in the message.
+
+        Returns:
+            str: Formatted string representing the anomaly.
+        """
+        pass
+
+    def setup(self, data: list[dict[str, str | float | int | datetime]], message: str):
+        """
+        Prepares the email message with given data and a custom message.
+
+        Parameters:
+            data (list[dict[str, str | float | int | datetime]]): Data to be included in the email.
+            message (str): A custom message to be included in the email.
+
+        Returns:
+            None: This method prepares the email content.
+        """
+        pass
+
+    @property
+    def send(self):
+        """
+        Synchronously sends the prepared email to the specified addresses.
+
+        Parameters:
+            * None
+
+        Returns:
+            None: Sends notification via sender address and prints the status of the operation.
+        """
+        pass

--- a/src/detecto/models/notifications/slack.py
+++ b/src/detecto/models/notifications/slack.py
@@ -8,7 +8,7 @@ from src.detecto.models.notifications.interface import Notification
 
 class SlackNotification(Notification):
     """
-    Initializes a new instance of SlackNotification.
+    Notification class that setups message for your anomalies and sends them to Slack via webhook.
 
     # Attributes:
         * webhook_url (str): The URL of the Slack webhook used to send notifications.
@@ -20,6 +20,7 @@ class SlackNotification(Notification):
         self.webhook_url = webhook_url
         self.__headers: dict[str, str] = {"Content-Type": "application/json"}
         self.__payload: str = ""
+        self.__subject: str = "🤖 Detecto: Anomaly detected!"
 
     def __format_data(self, data: dict[str, str | float | int | datetime], index: int):
         """
@@ -63,9 +64,9 @@ class SlackNotification(Notification):
             self.__format_data(data=anomaly_data, index=index) for index, anomaly_data in enumerate(data)
         )
         if not message:
-            fmt_message = "🤖 Detecto: Anomaly detected!\n" f"\n\n{fmt_data}"
+            fmt_message = f"{self.__subject}\n" f"\n\n{fmt_data}"
         else:
-            fmt_message = "🤖 Detecto: Anomaly detected!\n" f"\n\n{message}\n" f"\n\n{fmt_data}"
+            fmt_message = f"{self.__subject}\n" f"\n\n{message}\n" f"\n\n{fmt_data}"
         self.__payload = dumps({"text": fmt_message})
 
     @property
@@ -82,10 +83,10 @@ class SlackNotification(Notification):
         if len(self.__payload) == 0:
             raise ValueError("Payload not set. Please call `setup()` method first.")
 
-        parsed_url = urlparse(self.webhook_url)
+        parsed_url = urlparse(url=self.webhook_url)
         connection = client.HTTPSConnection(parsed_url.netloc)
 
-        connection.request("POST", parsed_url.path, body=self.__payload, headers=self.__headers)
+        connection.request(method="POST", url=parsed_url.path, body=self.__payload, headers=self.__headers)
         response = connection.getresponse()
 
         if response.status == 200:

--- a/tests/unit_tests/notifications/test_email_notification.py
+++ b/tests/unit_tests/notifications/test_email_notification.py
@@ -1,0 +1,135 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from src.detecto.models.notifications.email import EmailNotification
+from src.detecto.models.notifications.interface import Notification
+
+
+class TestEmailNotification(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.gmail_notification = EmailNotification(
+            sender_address="example@gmail.com",
+            password="password",
+            recipient_addresses=["recipient1@gmail.com", "recipient2@web.de"],
+            smtp_host="smtp.gmail.com",
+            smtp_port=587,
+        )
+        self.webde_notification = EmailNotification(
+            sender_address="example@web.de",
+            password="password",
+            recipient_addresses=["recipient1@gmail.com", "recipient2@web.de"],
+            smtp_host="smtp.web.de",
+            smtp_port=587,
+        )
+        self.test_message = "Test notification message"
+        self.test_data = [
+            {"date": "2023-10-23T00:00:00.000Z", "column": "col_1", "anomaly": 2003.214},
+            {"date": "2023-10-23T00:00:00.000Z", "column": "col_2", "anomaly": 1055.67},
+        ]
+
+    def test_instance_is_abstract_class(self):
+        self.assertIsInstance(obj=self.gmail_notification, cls=Notification)
+        self.assertEqual(first=type(self.gmail_notification._EmailNotification__payload), second=str)  # type: ignore
+        self.assertEqual(first=len(self.gmail_notification._EmailNotification__payload), second=0)  # type: ignore
+        self.assertEqual(first=self.gmail_notification._EmailNotification__payload, second="")  # type: ignore
+        self.assertEqual(first=type(self.gmail_notification._EmailNotification__subject), second=str)  # type: ignore
+        self.assertEqual(
+            first=self.gmail_notification._EmailNotification__subject, second="🤖 Detecto: Anomaly detected!"  # type: ignore
+        )
+
+        self.assertIsInstance(obj=self.webde_notification, cls=Notification)
+        self.assertEqual(first=type(self.webde_notification._EmailNotification__payload), second=str)  # type: ignore
+        self.assertEqual(first=len(self.webde_notification._EmailNotification__payload), second=0)  # type: ignore
+        self.assertEqual(first=self.webde_notification._EmailNotification__payload, second="")  # type: ignore
+        self.assertEqual(first=type(self.webde_notification._EmailNotification__subject), second=str)  # type: ignore
+        self.assertEqual(
+            first=self.webde_notification._EmailNotification__subject, second="🤖 Detecto: Anomaly detected!"  # type: ignore
+        )
+
+    def test_string_method(self):
+        self.assertTrue(expr=str(self.gmail_notification) == "Email Notification Class")
+        self.assertTrue(expr=str(self.webde_notification) == "Email Notification Class")
+
+    def test_setup_with_wrong_data_type(self):
+        with self.assertRaises(expected_exception=TypeError):
+            self.gmail_notification.setup(data=self.test_data[0], message=self.test_message)  # type: ignore
+
+        with self.assertRaises(expected_exception=TypeError):
+            self.webde_notification.setup(data=self.test_data[0], message=self.test_message)  # type: ignore
+
+    def test_setup_with_wrong_data_type_first_nested(self):
+        with self.assertRaises(expected_exception=TypeError):
+            self.gmail_notification.setup(
+                data=[("date", "2023-10-23T00:00:00.000Z"), ("column", "col_1"), ("anomaly", 2003.214)],  # type: ignore
+                message=self.test_message,
+            )
+
+        with self.assertRaises(expected_exception=TypeError):
+            self.webde_notification.setup(
+                data=[("date", "2023-10-23T00:00:00.000Z"), ("column", "col_1"), ("anomaly", 2003.214)],  # type: ignore
+                message=self.test_message,
+            )
+
+    def test_setup_with_wrong_key_name(self):
+        with self.assertRaises(expected_exception=KeyError):
+            self.gmail_notification.setup(  # type: ignore
+                data=[{"date": "2023-10-23T00:00:00.000Z", "col": "col_1", "anomaly_value": 1055.67}],  # type: ignore
+                message=self.test_message,
+            )
+
+        with self.assertRaises(expected_exception=KeyError):
+            self.webde_notification.setup(  # type: ignore
+                data=[{"date": "2023-10-23T00:00:00.000Z", "col": "col_1", "anomaly_value": 1055.67}],  # type: ignore
+                message=self.test_message,
+            )
+
+    def test_format_data_method(self):
+        expected_fmt_data = "1. Date: 2023-10-23T00:00:00.000Z | Column: col_1 | Anomaly: 2003.214"
+        fmt_gmail_data = self.gmail_notification._EmailNotification__format_data(data=self.test_data[0], index=0)  # type: ignore
+        fmt_webde_data = self.gmail_notification._EmailNotification__format_data(data=self.test_data[0], index=0)  # type: ignore
+
+        self.assertEqual(first=fmt_gmail_data, second=expected_fmt_data)
+        self.assertEqual(first=fmt_webde_data, second=expected_fmt_data)
+
+    def test_setup(self):
+        expected_payload = (
+            f"{self.test_message}\n\n"  # Note the double \n here for the gap between message and first anomaly
+            "1. Date: 2023-10-23T00:00:00.000Z | Column: col_1 | Anomaly: 2003.214\n"  # \n at the end of this line
+            "2. Date: 2023-10-23T00:00:00.000Z | Column: col_2 | Anomaly: 1055.67"
+        )
+
+        self.gmail_notification.setup(data=self.test_data, message=self.test_message)  # type: ignore
+        self.webde_notification.setup(data=self.test_data, message=self.test_message)  # type: ignore
+
+        self.assertNotEqual(first=self.gmail_notification._EmailNotification__payload, second="")  # type: ignore
+        self.assertNotEqual(first=self.webde_notification._EmailNotification__payload, second="")  # type: ignore
+        self.assertEqual(first=self.gmail_notification._EmailNotification__payload, second=expected_payload)  # type: ignore
+        self.assertEqual(first=self.webde_notification._EmailNotification__payload, second=expected_payload)  # type: ignore
+
+    @patch("src.detecto.models.notifications.email.SMTP")
+    def test_send_gmail(self, mock_smtp):
+        mock_smtp.return_value = MagicMock()
+
+        self.gmail_notification.setup(data=self.test_data, message=self.test_message)  # type: ignore
+        self.gmail_notification.send
+
+        mock_smtp.assert_called_with(host="smtp.gmail.com", port=587)
+        mock_smtp.return_value.starttls.assert_called_once()
+        mock_smtp.return_value.login.assert_called_once_with(user="example@gmail.com", password="password")
+        mock_smtp.return_value.quit.assert_called_once()
+
+    @patch("src.detecto.models.notifications.email.SMTP")
+    def test_send_webde(self, mock_smtp):
+        mock_smtp.return_value = MagicMock()
+
+        self.webde_notification.setup(data=self.test_data, message=self.test_message)  # type: ignore
+        self.webde_notification.send
+
+        mock_smtp.assert_called_with(host="smtp.web.de", port=587)
+        mock_smtp.return_value.starttls.assert_called_once()
+        mock_smtp.return_value.login.assert_called_once_with(user="example@web.de", password="password")
+        mock_smtp.return_value.quit.assert_called_once()
+
+    def tearDown(self) -> None:
+        return super().tearDown()

--- a/tests/unit_tests/notifications/test_slack_notification.py
+++ b/tests/unit_tests/notifications/test_slack_notification.py
@@ -18,6 +18,13 @@ class TestSlackNotification(TestCase):
 
     def test_instance_is_abstract_class(self):
         self.assertIsInstance(obj=self.slack_notification, cls=Notification)
+        self.assertEqual(first=type(self.slack_notification._SlackNotification__payload), second=str)  # type: ignore
+        self.assertEqual(first=len(self.slack_notification._SlackNotification__payload), second=0)  # type: ignore
+        self.assertEqual(first=self.slack_notification._SlackNotification__payload, second="")  # type: ignore
+        self.assertEqual(first=type(self.slack_notification._SlackNotification__subject), second=str)  # type: ignore
+        self.assertEqual(
+            first=self.slack_notification._SlackNotification__subject, second="🤖 Detecto: Anomaly detected!"  # type: ignore
+        )
 
     def test_string_method(self):
         self.assertTrue(expr=str(self.slack_notification) == "Slack Notification Class")


### PR DESCRIPTION
- [X] Create `EmailNotification` class to send notification via email.
- [X] Implement the email notification for general email providers viaSMTP (NOT only Gmail 😎).
- [X] Provide unit tests to ensure that
    - [X] `setup()` prepares the message correctly as per template
    - [X] `send()` compose all the email components and send it from and ato the right email addresses via SMTP server
- [X] Add and fix dockstring for all `Notification` classes.

closes #23
closes #24 