### PR TITLE
feat(pot-detecto-attributes): convert potdetecto methods to store results in attributes

### DIFF
--- a/src/detecto/models/detectors/interface.py
+++ b/src/detecto/models/detectors/interface.py
@@ -5,27 +5,27 @@ from pandas import DataFrame
 
 class Detecto(metaclass=ABCMeta):
     @abstractmethod
-    def fit(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def fit(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         """
         Train the anomaly detection model using the provided data.
 
         Parameters:
-        - dataset (DataFrame or array-like): Input data for training.
+        * kwargs (DataFrame | list | str | int | float | None): The parameters depend on the detection method.
 
         Returns:
-        - None
+        * None: The result is assigned to the class attribute.
         """
 
     @abstractmethod
-    def detect(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         """
         Predict if the provided data points are anomalies based on the trained model.
 
         Parameters:
-        - dataset (DataFrame or array-like): Data for which predictions are to be made.
+        * kwargs (DataFrame | list | str | int | float | None): The parameters depend on the detection method.
 
         Returns:
-        - predictions (DataFrame): Binary labels indicating anomalies (1 for anomaly, 0 otherwise).
+        * None: The result is assigned to the class attribute.
         """
 
     @abstractmethod
@@ -34,11 +34,11 @@ class Detecto(metaclass=ABCMeta):
         Evaluate the performance of the anomaly detection model based on true and predicted labels.
 
         Parameters:
-        - dataset (DataFrame or array-like): Data for which predictions are to be made.
-        - detected (DataFrame | array-like): Detected labels from the model.
+        * dataset (DataFrame): Data for which predictions are to be made.
+        * kwargs (DataFrame | list | str | int | float | None): The parameters depend on the detection method.
 
         Returns:
-        - metrics (DataFrame): Performance metrics.
+        * None: The result is assigned to the class attribute.
         """
 
     @property
@@ -48,7 +48,7 @@ class Detecto(metaclass=ABCMeta):
         Retrieve the parameters of the anomaly detection model.
 
         Returns:
-        - params (dict[str | int, str | int | float | None | dict[str | int, str | int | float | None]]): Current parameters of the model.
+        * (dict[str | int, str | int | float | None | dict[str | int, str | int | float | None]]): Current parameters of the model.
         """
 
     @abstractmethod
@@ -57,8 +57,8 @@ class Detecto(metaclass=ABCMeta):
         Set the parameters for the anomaly detection model.
 
         Parameters:
-        - **kwargs (dict[str, str | int | float | None]): Parameters to be set for the model.
+        * **kwargs (dict[str, str | int | float | None]): Parameters to be recorded from the model fitting.
 
         Returns:
-        - None
+        * None: The result is assigned to the class private attribute `__params`.
         """

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -153,7 +153,7 @@ class POTDetecto(Detecto):
         )
         self.__params[kwargs.get("row")].append(data)
 
-    def compute_exceedance_threshold(self, dataset: DataFrame, q: float = 0.99) -> DataFrame:
+    def compute_exceedance_threshold(self, dataset: DataFrame, q: float = 0.99) -> None:
         """
         Calculate the exceedance threshold for each feature in the dataset.
 
@@ -164,7 +164,7 @@ class POTDetecto(Detecto):
         # Returns
             * DataFrame: The threshold values for each feature.
         """
-        return dataset.expanding(min_periods=self.timeframe.t0).quantile(q=q).bfill()
+        self.exceedance_threshold_dataset = dataset.expanding(min_periods=self.timeframe.t0).quantile(q=q).bfill()
 
     def extract_exceedance(
         self,

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -197,7 +197,7 @@ class POTDetecto(Detecto):
         if type(dataset) != DataFrame:
             raise ValueError("The `dataset` parameter needs to be a Pandas DataFrame!")
 
-        if not self.exceedance_threshold_dataset:
+        if type(self.exceedance_threshold_dataset) == None:
             raise ValueError(
                 "The `exceedance_threshold_dataset` is not set! Call `compute_exceedance_threshold()` first!"
             )
@@ -223,10 +223,9 @@ class POTDetecto(Detecto):
         """
         dataset: DataFrame = kwargs.get("dataset", None)
 
-        if not dataset:
+        if type(dataset) == None:
             raise ValueError("The `dataset` parameter can't be None. Please assign your original dataset!")
-
-        if type(dataset) != DataFrame:
+        elif type(dataset) != DataFrame:
             raise ValueError("The `dataset` parameter needs to be a Pandas DataFrame!")
 
         anomaly_scores = dataset.drop(dataset.index).add_prefix("anomaly_score_").to_dict(orient="list")
@@ -291,11 +290,11 @@ class POTDetecto(Detecto):
         self.anomaly_score_dataset = DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, q: float = 0.80):
-        if not self.anomaly_score_dataset:
+        if type(self.anomaly_score_dataset) == None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 
         try:
-            filtered_dataset: DataFrame = (
+            anomaly_scores = (
                 self.anomaly_score_dataset[  # type: ignore
                     (self.anomaly_score_dataset["total_anomaly_score"] > 0)  # type: ignore
                     & (self.anomaly_score_dataset["total_anomaly_score"] != float("inf"))  # type: ignore
@@ -307,19 +306,19 @@ class POTDetecto(Detecto):
             print(e)
             raise
 
-        if len(filtered_dataset) == 0:
+        if len(anomaly_scores) == 0:
             raise ValueError("There are no total anomaly scores per row > 0")
 
         self.anomaly_threshold = quantile(
-            a=filtered_dataset,
+            a=anomaly_scores,
             q=q,
         )
 
     def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
-        if not self.anomaly_score_dataset:
+        if type(self.anomaly_score_dataset) == None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 
-        if not self.anomaly_threshold:
+        if type(self.anomaly_threshold) == None:
             raise ValueError("`anomaly_threshold` is not set yet. Need to call `compute_anomaly_threshold()` first!")
 
         anomaly_data = {}

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -283,7 +283,7 @@ class POTDetecto(Detecto):
             t2_dataset["total_anomaly_score"].apply(lambda x: x > self.anomaly_threshold).to_list()
         )
 
-        return DataFrame(data=anomaly_data)
+        self.anomaly_dataset = DataFrame(data=anomaly_data)
 
     def evaluate(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         pass

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -18,7 +18,11 @@ class POTDetecto(Detecto):
 
     def __init__(self):
         self.timeframe = POTTimeframe()
+        self.exceedance_threshold_dataset = None
+        self.exceedance_dataset = None
+        self.anomaly_score_dataset = None
         self.anomaly_threshold = None
+        self.anomaly_dataset = None
         self.__params = {}
 
     def __set_params_structure(self, total_rows: int) -> None:
@@ -26,7 +30,7 @@ class POTDetecto(Detecto):
         Initialize the parameter structure for storing model parameters.
 
         # Parameters
-            * feature_names (list[int]): A registry of GPD parameters and statistics per row index and feature.
+            * total_rows (list[int]): The total number of row index from the dataset.
 
         # Returns
             * None: Create structure assigned to `__params` attribute.

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -189,7 +189,7 @@ class POTDetecto(Detecto):
             lower=clip_lower
         )
 
-    def fit(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def fit(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> None:
         """
         Fit the POT model on the dataset and calculate anomaly scores for each feature.
 
@@ -261,7 +261,7 @@ class POTDetecto(Detecto):
                 feature_name="total_anomaly_score", row=row, total_anomaly_score_per_row=total_anomaly_score_per_row
             )
             anomaly_scores["total_anomaly_score"].append(total_anomaly_score_per_row)
-        return DataFrame(data=anomaly_scores)
+        self.anomaly_score_dataset = DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, dataset: DataFrame, q: float = 0.80):
         clean_dataset = dataset[

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -167,7 +167,7 @@ class POTDetecto(Detecto):
         if type(dataset) != DataFrame:
             raise ValueError("The `dataset` parameter needs to be a Pandas DataFrame!")
 
-        if not self.timeframe.t0:
+        if self.timeframe.t0 is None:
             raise ValueError("The `t0` period is not set! Call `timeframe.set_interval()` first!")
 
         try:
@@ -197,15 +197,15 @@ class POTDetecto(Detecto):
         if type(dataset) != DataFrame:
             raise ValueError("The `dataset` parameter needs to be a Pandas DataFrame!")
 
-        if type(self.exceedance_threshold_dataset) == None:
+        if self.exceedance_threshold_dataset is None:
             raise ValueError(
                 "The `exceedance_threshold_dataset` is not set! Call `compute_exceedance_threshold()` first!"
             )
 
         try:
-            self.exceedance_dataset = dataset.subtract(self.exceedance_threshold_dataset, fill_value=fill_value).clip(
-                lower=clip_lower
-            )
+            self.exceedance_dataset = dataset.subtract(
+                other=self.exceedance_threshold_dataset, fill_value=fill_value
+            ).clip(lower=clip_lower)
         except Exception as e:
             print(e)
             raise
@@ -223,7 +223,7 @@ class POTDetecto(Detecto):
         """
         dataset: DataFrame = kwargs.get("dataset", None)
 
-        if type(dataset) == None:
+        if dataset is None:
             raise ValueError("The `dataset` parameter can't be None. Please assign your original dataset!")
         elif type(dataset) != DataFrame:
             raise ValueError("The `dataset` parameter needs to be a Pandas DataFrame!")
@@ -290,7 +290,7 @@ class POTDetecto(Detecto):
         self.anomaly_score_dataset = DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, q: float = 0.80):
-        if type(self.anomaly_score_dataset) == None:
+        if self.anomaly_score_dataset is None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 
         try:
@@ -315,10 +315,10 @@ class POTDetecto(Detecto):
         )
 
     def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
-        if type(self.anomaly_score_dataset) == None:
+        if self.anomaly_score_dataset is None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 
-        if type(self.anomaly_threshold) == None:
+        if self.anomaly_threshold is None:
             raise ValueError("`anomaly_threshold` is not set yet. Need to call `compute_anomaly_threshold()` first!")
 
         anomaly_data = {}

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -172,7 +172,7 @@ class POTDetecto(Detecto):
         exceedance_threshold_dataset: DataFrame,
         fill_value: float | None = 0.0,
         clip_lower: float | None = 0.0,
-    ) -> DataFrame:
+    ) -> None:
         """
         Extract values from the dataset that exceed the threshold values.
 
@@ -185,7 +185,9 @@ class POTDetecto(Detecto):
         # Returns
             * DataFrame: The dataset with values exceeding the thresholds.
         """
-        return dataset.subtract(exceedance_threshold_dataset, fill_value=fill_value).clip(lower=clip_lower)
+        self.exceedance_dataset = dataset.subtract(exceedance_threshold_dataset, fill_value=fill_value).clip(
+            lower=clip_lower
+        )
 
     def fit(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         """

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -44,7 +44,7 @@ class POTDetecto(Detecto):
         Get the parameters set from model fitting.
 
         # Returns
-            * dict[Str, list[dict[int, dict[str, float | None]]]]: A dictionary containing the GPD fit parameters and statistics for each row and feature.
+            * dict[str, list[dict[int, dict[str, float | None]]]]: A dictionary containing the GPD fit parameters and statistics for each row and feature.
         """
         return self.__params
 
@@ -216,7 +216,7 @@ class POTDetecto(Detecto):
 
         # Parameters
             * kwargs:
-                * dataset (DataFrame): The dataset on which the POT model is to be fitted.
+                * dataset (DataFrame): The original timeseries dataset on which the POT model is to be fitted.
 
         # Returns
             * DataFrame: Anomaly scores for each feature in the dataset.
@@ -290,6 +290,16 @@ class POTDetecto(Detecto):
         self.anomaly_score_dataset = DataFrame(data=anomaly_scores)
 
     def compute_anomaly_threshold(self, q: float = 0.80):
+        """
+        Claculate the anomaly threshold with quantile method to be used to detect the anomalies.
+
+        # Parameters
+            * kwargs:
+                * q (float): The quantile to calculate the threshold, range values are 0.0 - 1.0.
+
+        # Returns
+            * float: The threshold for anomalous data.
+        """
         if self.anomaly_score_dataset is None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 
@@ -315,6 +325,16 @@ class POTDetecto(Detecto):
         )
 
     def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+        """
+        Claculate the anomaly threshold with quantile method to be used to detect the anomalies.
+
+        # Parameters
+            * kwargs:
+                * None: No parameters needed for this method.
+
+        # Returns
+            * DataFrame: The final dataset with boolean values where `True` indicates an anomaly.
+        """
         if self.anomaly_score_dataset is None:
             raise ValueError("`anomaly_score_dataset` is still None. Need to call `.fit()` first!")
 

--- a/src/detecto/models/timeframes/pot.py
+++ b/src/detecto/models/timeframes/pot.py
@@ -24,10 +24,10 @@ class POTTimeframe(Timeframe):
         # Parameters
             * #### kwargs
                 * total_rows (int): The total number of rows in the dataset.
-                * t0_percentage (float): The percentage of the total rows to use for learning the normal behavior.
-                * t1_percentage (float): The percentage of the total rows to use for setting the threshold.
-                * t2_percentage (float): The percentage of the total rows to use for detecting anomalies.
-                * prod_mode (bool): A flag indicating whether the model is in production mode, which affects the interval calculations.
+                * t0_percentage (float | None): The percentage of the total rows to use for learning the normal behavior, default 0.6.
+                * t1_percentage (float | None): The percentage of the total rows to use for setting the threshold, default 0.25.
+                * t2_percentage (float | None): The percentage of the total rows to use for detecting anomalies, default 0.15.
+                * prod_mode (bool): A flag indicating whether the model is in production mode, which affects the interval calculations, default False.
 
         # Returns
             * None: Calculate the percentage of t0, t1, t2 and assign them to t0, t1, and t2.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,10 @@ from src.detecto.models.timeframes.interface import Timeframe
 
 
 class AbstractDetectoTestModel(Detecto):
-    def fit(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def fit(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         pass
 
-    def detect(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         pass
 
     def evaluate(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:

--- a/tests/unit_tests/detectors/test_detecto.py
+++ b/tests/unit_tests/detectors/test_detecto.py
@@ -17,10 +17,10 @@ class TestDetectoInterfaceClass(TestCase):
         )
 
     def test_fit(self):
-        self.assertIsNone(obj=self.detector.fit(dataset=self.test_df))
+        self.assertIsNone(obj=self.detector.fit())
 
     def test_detect(self):
-        self.assertIsNone(obj=self.detector.detect(dataset=self.test_df))
+        self.assertIsNone(obj=self.detector.detect())
 
     def test_evaluate(self):
         self.assertIsNone(obj=self.detector.evaluate(dataset=self.test_df))

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -96,19 +96,19 @@ class TestPOTDetecto(TestCase):
                 ],
             }
         )
-        exceedance_df = self.detector.extract_exceedance(
+        self.detector.extract_exceedance(
             dataset=self.df_1,
             exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
             fill_value=0.0,
             clip_lower=0.0,
         )
 
-        pd_testing.assert_frame_equal(left=exceedance_df, right=expected_exceedance_df)
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
         pd_testing.assert_series_equal(
-            left=exceedance_df["df_1_feature_1"], right=expected_exceedance_df["df_1_feature_1"]
+            left=self.detector.exceedance_dataset["df_1_feature_1"], right=expected_exceedance_df["df_1_feature_1"]  # type: ignore
         )
         pd_testing.assert_series_equal(
-            left=exceedance_df["df_1_feature_2"], right=expected_exceedance_df["df_1_feature_2"]
+            left=self.detector.exceedance_dataset["df_1_feature_2"], right=expected_exceedance_df["df_1_feature_2"]  # type: ignore
         )
 
     def test_genpareto_fitting_method_with_90_quantile(self):
@@ -138,16 +138,16 @@ class TestPOTDetecto(TestCase):
             left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
         )
 
-        exceedance_data_df = self.detector.extract_exceedance(
+        self.detector.extract_exceedance(
             dataset=self.df_1,
             exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
             fill_value=0.0,
             clip_lower=0.0,
         )
 
-        pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=self.df_1, exceedance_dataset=exceedance_data_df)
+        anomaly_score_df = self.detector.fit(dataset=self.df_1, exceedance_dataset=self.detector.exceedance_dataset)
 
         pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
 
@@ -555,16 +555,16 @@ class TestPOTDetecto(TestCase):
             left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
         )
 
-        exceedance_data_df = self.detector.extract_exceedance(
+        self.detector.extract_exceedance(
             dataset=test_df,
             exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
             fill_value=0.0,
             clip_lower=0.0,
         )
 
-        pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=exceedance_data_df)
+        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
 
         pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
 
@@ -989,16 +989,16 @@ class TestPOTDetecto(TestCase):
             left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
         )
 
-        exceedance_data_df = self.detector.extract_exceedance(
+        self.detector.extract_exceedance(
             dataset=test_df,
             exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
             fill_value=0.0,
             clip_lower=0.0,
         )
 
-        pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=exceedance_data_df)
+        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
 
         pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
 

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -147,9 +147,9 @@ class TestPOTDetecto(TestCase):
 
         pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=self.df_1, exceedance_dataset=self.detector.exceedance_dataset)
+        self.detector.fit(dataset=self.df_1, exceedance_dataset=self.detector.exceedance_dataset)
 
-        pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
+        pd_testing.assert_frame_equal(left=self.detector.anomaly_score_dataset, right=expected_anomaly_score_df)
 
     def test_compute_anomaly_threshold_method(self):
         expected_anomaly_threshold = 2.04403430931313
@@ -564,11 +564,11 @@ class TestPOTDetecto(TestCase):
 
         pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
+        self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
 
-        pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
+        pd_testing.assert_frame_equal(left=self.detector.anomaly_score_dataset, right=expected_anomaly_score_df)
 
-        self.detector.compute_anomaly_threshold(dataset=anomaly_score_df, q=0.90)
+        self.detector.compute_anomaly_threshold(dataset=self.detector.anomaly_score_dataset, q=0.90)
 
         self.assertEqual(first=self.detector.anomaly_threshold, second=expected_anomaly_threshold)
 
@@ -998,15 +998,15 @@ class TestPOTDetecto(TestCase):
 
         pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
 
-        anomaly_score_df = self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
+        self.detector.fit(dataset=test_df, exceedance_dataset=self.detector.exceedance_dataset)
 
-        pd_testing.assert_frame_equal(left=anomaly_score_df, right=expected_anomaly_score_df)
+        pd_testing.assert_frame_equal(left=self.detector.anomaly_score_dataset, right=expected_anomaly_score_df)
 
-        self.detector.compute_anomaly_threshold(dataset=anomaly_score_df, q=0.90)
+        self.detector.compute_anomaly_threshold(dataset=self.detector.anomaly_score_dataset, q=0.90)
 
         self.assertEqual(first=self.detector.anomaly_threshold, second=expected_anomaly_threshold)
 
-        anomaly_df = self.detector.detect(dataset=anomaly_score_df)
+        anomaly_df = self.detector.detect(dataset=self.detector.anomaly_score_dataset)
 
         pd_testing.assert_frame_equal(left=anomaly_df, right=expected_anomaly_df)
 

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -37,7 +37,7 @@ class TestPOTDetecto(TestCase):
         self.assertIsNone(obj=self.detector.evaluate(dataset=self.df_1, detected=expected_detected_df))
 
     def test_compute_exceedance_threshold_method(self):
-        exceedance_threshold_df = self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.99)
+        self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.99)
 
         expected_exceedance_threshold = DataFrame(
             data={
@@ -46,12 +46,14 @@ class TestPOTDetecto(TestCase):
             }
         )
 
-        pd_testing.assert_frame_equal(left=exceedance_threshold_df, right=expected_exceedance_threshold)
-        pd_testing.assert_series_equal(
-            left=exceedance_threshold_df["df_1_feature_1"], right=expected_exceedance_threshold["df_1_feature_1"]  # type: ignore
+        pd_testing.assert_frame_equal(
+            left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold
         )
         pd_testing.assert_series_equal(
-            left=exceedance_threshold_df["df_1_feature_2"], right=expected_exceedance_threshold["df_1_feature_2"]  # type: ignore
+            left=self.detector.exceedance_threshold_dataset["df_1_feature_1"], right=expected_exceedance_threshold["df_1_feature_1"]  # type: ignore
+        )
+        pd_testing.assert_series_equal(
+            left=self.detector.exceedance_threshold_dataset["df_1_feature_2"], right=expected_exceedance_threshold["df_1_feature_2"]  # type: ignore
         )
 
     def test_extract_exeedance_method(self):
@@ -62,9 +64,9 @@ class TestPOTDetecto(TestCase):
             }
         )
 
-        exceedance_threshold_df = self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.99)
+        self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.99)
 
-        pd_testing.assert_frame_equal(left=exceedance_threshold_df, right=expected_threshold_df)
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_threshold_dataset, right=expected_threshold_df)
 
         expected_exceedance_df = DataFrame(
             data={
@@ -95,7 +97,10 @@ class TestPOTDetecto(TestCase):
             }
         )
         exceedance_df = self.detector.extract_exceedance(
-            dataset=self.df_1, exceedance_threshold_dataset=exceedance_threshold_df, fill_value=0.0, clip_lower=0.0
+            dataset=self.df_1,
+            exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
+            fill_value=0.0,
+            clip_lower=0.0,
         )
 
         pd_testing.assert_frame_equal(left=exceedance_df, right=expected_exceedance_df)
@@ -127,12 +132,17 @@ class TestPOTDetecto(TestCase):
             }
         )
 
-        exceedance_threshold_df = self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.90)
+        self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.90)
 
-        pd_testing.assert_frame_equal(left=exceedance_threshold_df, right=expected_exceedance_threshold_df)
+        pd_testing.assert_frame_equal(
+            left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
+        )
 
         exceedance_data_df = self.detector.extract_exceedance(
-            dataset=self.df_1, exceedance_threshold_dataset=exceedance_threshold_df, fill_value=0.0, clip_lower=0.0
+            dataset=self.df_1,
+            exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
+            fill_value=0.0,
+            clip_lower=0.0,
         )
 
         pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)
@@ -539,12 +549,17 @@ class TestPOTDetecto(TestCase):
             }
         )
 
-        exceedance_threshold_df = self.detector.compute_exceedance_threshold(dataset=test_df, q=0.90)
+        self.detector.compute_exceedance_threshold(dataset=test_df, q=0.90)
 
-        pd_testing.assert_frame_equal(left=exceedance_threshold_df, right=expected_exceedance_threshold_df)
+        pd_testing.assert_frame_equal(
+            left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
+        )
 
         exceedance_data_df = self.detector.extract_exceedance(
-            dataset=test_df, exceedance_threshold_dataset=exceedance_threshold_df, fill_value=0.0, clip_lower=0.0
+            dataset=test_df,
+            exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
+            fill_value=0.0,
+            clip_lower=0.0,
         )
 
         pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)
@@ -968,12 +983,17 @@ class TestPOTDetecto(TestCase):
             }
         )
 
-        exceedance_threshold_df = self.detector.compute_exceedance_threshold(dataset=test_df, q=0.90)
+        self.detector.compute_exceedance_threshold(dataset=test_df, q=0.90)
 
-        pd_testing.assert_frame_equal(left=exceedance_threshold_df, right=expected_exceedance_threshold_df)
+        pd_testing.assert_frame_equal(
+            left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
+        )
 
         exceedance_data_df = self.detector.extract_exceedance(
-            dataset=test_df, exceedance_threshold_dataset=exceedance_threshold_df, fill_value=0.0, clip_lower=0.0
+            dataset=test_df,
+            exceedance_threshold_dataset=self.detector.exceedance_threshold_dataset,
+            fill_value=0.0,
+            clip_lower=0.0,
         )
 
         pd_testing.assert_frame_equal(left=exceedance_data_df, right=expected_exceedance_df)

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -1006,9 +1006,9 @@ class TestPOTDetecto(TestCase):
 
         self.assertEqual(first=self.detector.anomaly_threshold, second=expected_anomaly_threshold)
 
-        anomaly_df = self.detector.detect(dataset=self.detector.anomaly_score_dataset)
+        self.detector.detect(dataset=self.detector.anomaly_score_dataset)
 
-        pd_testing.assert_frame_equal(left=anomaly_df, right=expected_anomaly_df)
+        pd_testing.assert_frame_equal(left=self.detector.anomaly_dataset, right=expected_anomaly_df)
 
     def test_evaluate_method(self):
         pass


### PR DESCRIPTION
- [X] The following attributes are created to store each calculation stage of anomaly detection using `POTDetecto`:
  - [X] `self.exceedance_threshold_dataset `: Dataset that stores the quantile score from each cell of the original dataset.
  - [X] `self.exceedance_dataset`: Dataset that holds the POT data, data that are above the exceedance threshold.
  - [X] `self.anomaly_score_dataset`: Dataset that holds the result of genpareto fitting (inverted p-value).
  - [X] `self.anomaly_dataset`: The final dataset that indicates the detected anomalies (or not) by the boolean values.
- [X] Add docstring for `fit()` and `detect()` methods in `POTDetecto` class.
- [X] Adjust all unit tests for `POTDetecto` to target the datasets in the class' attributes.
- [X] Write unit test to ensure the trigger of error-handler in each `POTDetecto` method is functioning correctly.

closes #32