### PR TITLE
feat(statistical-test): implement "Kolmogorov Smirnov" test for `evaluate()` method in `POTDetecto`

### DIFF
--- a/src/detecto/models/detectors/interface.py
+++ b/src/detecto/models/detectors/interface.py
@@ -29,12 +29,11 @@ class Detecto(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def evaluate(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def evaluate(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         """
         Evaluate the performance of the anomaly detection model based on true and predicted labels.
 
         Parameters:
-        * dataset (DataFrame): Data for which predictions are to be made.
         * kwargs (DataFrame | list | str | int | float | None): The parameters depend on the detection method.
 
         Returns:

--- a/src/detecto/models/detectors/interface.py
+++ b/src/detecto/models/detectors/interface.py
@@ -5,7 +5,7 @@ from pandas import DataFrame
 
 class Detecto(metaclass=ABCMeta):
     @abstractmethod
-    def fit(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def fit(self, **kwargs: DataFrame | list | str | int | float | None) -> None:
         """
         Train the anomaly detection model using the provided data.
 
@@ -17,7 +17,7 @@ class Detecto(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> None:
         """
         Predict if the provided data points are anomalies based on the trained model.
 
@@ -29,7 +29,7 @@ class Detecto(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def evaluate(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def evaluate(self, **kwargs: DataFrame | list | str | int | float | None) -> None:
         """
         Evaluate the performance of the anomaly detection model based on true and predicted labels.
 

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -11,9 +11,14 @@ class POTDetecto(Detecto):
     POTDetecto class implements the Peaks Over Threshold (POT) approach for anomaly detection.
 
     # Attributes
-        * timeframe (POTTimeframe): Instance managing the timeframe details for the POT method.
-        * anomaly_threshold (float): The threshold to measure the anomalous data.
-        * __params (dict): Private dictionary to store parameters after model fitting.
+        * timeframe (POTTimeframe): A timeframe instance that manages the time windows (t0, t1, t2) for the "Peak over Threshold" method.
+        * exceedance_threshold_dataset (DataFrame | None): A Pandas DataFrame that holds the threshold to get the exceedances, default is None.
+        * exceedance_dataset (DataFrame | None): A Pandas DataFrame that holds the exceedances, default is None.
+        * anomaly_score_dataset (DataFrame | None): A Pandas dataFrame the stores the anomaly scores from gen. pareto fitting, default is None.
+        * anomaly_threshold (DataFrame | None): A single float that serves as the threshold to measure the anomalous data, default is None.
+        * anomaly_dataset (DataFrame | None): A Pandas DataFrame that serves as the final dataset where anomalies are observable, default is None.
+        * ktest_result (DataFrame | None): The evaluation result of the exceedances and GPD params distribution via Kolmogorov Smirnov test, default is None.
+        * __params (dict[str, list[dict[int, dict[str, float | None]]]]): Private dictionary to store parameters after model fitting.
     """
 
     def __init__(self):

--- a/src/detecto/models/detectors/pot.py
+++ b/src/detecto/models/detectors/pot.py
@@ -400,6 +400,9 @@ class POTDetecto(Detecto):
         # Returns
             * None: The test result is a Pandas DataFrame, assigned to `kstest_result`.
         """
+        if not isinstance(nonzero_exceedance_dataset[0], Series):
+            raise ValueError("The element of `nonzero_exceedance_dataset` must be a Pandas Series!")
+
         kstest_results: dict = {}
 
         for feature_idx, feature_name in enumerate(self.exceedance_dataset.columns):  # type: ignore

--- a/src/detecto/models/timeframes/pot.py
+++ b/src/detecto/models/timeframes/pot.py
@@ -25,8 +25,8 @@ class POTTimeframe(Timeframe):
             * #### kwargs
                 * total_rows (int): The total number of rows in the dataset.
                 * t0_percentage (float | None): The percentage of the total rows to use for learning the normal behavior, default 0.6.
-                * t1_percentage (float | None): The percentage of the total rows to use for setting the threshold, default 0.25.
-                * t2_percentage (float | None): The percentage of the total rows to use for detecting anomalies, default 0.15.
+                * t1_percentage (float | None): The percentage of the total rows to use for setting the threshold, default 0.3.
+                * t2_percentage (float | None): The percentage of the total rows to use for detecting anomalies, default 0.1.
                 * prod_mode (bool): A flag indicating whether the model is in production mode, which affects the interval calculations, default False.
 
         # Returns
@@ -43,7 +43,7 @@ class POTTimeframe(Timeframe):
                 (t0_percentage - t1_percentage != 0.0) or (t1_percentage - t0_percentage != 0.0)
             ):
                 raise ValueError(
-                    "If `prod_mode` is True t2 always = 1. Hence t0_percentage + t1_percentage must equal to 1.0 (100%)."
+                    "If `prod_mode = True`, t2 always = 1. Hence `t0_percentage` + `t1_percentage` must equal to 1.0 (100%)."
                 )
 
             t2 = 1

--- a/src/detecto/models/timeframes/pot.py
+++ b/src/detecto/models/timeframes/pot.py
@@ -34,14 +34,19 @@ class POTTimeframe(Timeframe):
         """
         total_rows = kwargs.get("total_rows")
         t0_percentage = kwargs.get("t0_percentage", 0.6)
-        t1_percentage = kwargs.get("t1_percentage", 0.25)
-        t2_percentage = kwargs.get("t2_percentage", 0.15)
+        t1_percentage = kwargs.get("t1_percentage", 0.3)
+        t2_percentage = kwargs.get("t2_percentage", 0.1)
         prod_mode = kwargs.get("prod_mode", False)
 
         if prod_mode:
+            if ((t0_percentage + t1_percentage > 1.0 or t0_percentage + t1_percentage == 1.0)) and (
+                (t0_percentage - t1_percentage != 0.0) or (t1_percentage - t0_percentage != 0.0)
+            ):
+                raise ValueError(
+                    "If `prod_mode` is True t2 always = 1. Hence t0_percentage + t1_percentage must equal to 1.0 (100%)."
+                )
+
             t2 = 1
-            t0_percentage = 0.6
-            t1_percentage = 0.4
             total_rows = total_rows - t2  # type: ignore
             t0 = int(t0_percentage * total_rows)  # type: ignore
             t1 = int(t1_percentage * total_rows)  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ class AbstractDetectoTestModel(Detecto):
     def detect(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         pass
 
-    def evaluate(self, dataset: DataFrame, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
+    def evaluate(self, **kwargs: DataFrame | list | str | int | float | None) -> DataFrame:
         pass
 
     @property

--- a/tests/unit_tests/detectors/test_detecto.py
+++ b/tests/unit_tests/detectors/test_detecto.py
@@ -9,12 +9,6 @@ class TestDetectoInterfaceClass(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.detector = AbstractDetectoTestModel()
-        self.test_df = DataFrame(
-            data={
-                "col_1": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                "col_2": [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5],
-            }
-        )
 
     def test_fit(self):
         self.assertIsNone(obj=self.detector.fit())
@@ -23,7 +17,7 @@ class TestDetectoInterfaceClass(TestCase):
         self.assertIsNone(obj=self.detector.detect())
 
     def test_evaluate(self):
-        self.assertIsNone(obj=self.detector.evaluate(dataset=self.test_df))
+        self.assertIsNone(obj=self.detector.evaluate())
 
     def test_set_params(self):
         self.assertIsNone(obj=self.detector.set_params())  # type: ignore

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from pandas import DataFrame, testing as pd_testing
+from scipy.stats import genpareto, ks_1samp
 
 from src.detecto.models.detectors.interface import Detecto
 from src.detecto.models.detectors.pot import POTDetecto
@@ -157,6 +158,45 @@ class TestPOTDetecto(TestCase):
         self.detector.fit(dataset=self.df_1)
 
         pd_testing.assert_frame_equal(left=self.detector.anomaly_score_dataset, right=expected_anomaly_score_df)
+
+        exceedance_feature_1_df = expected_exceedance_df["df_1_feature_1"].copy()
+        exceedance_feature_2_df = expected_exceedance_df["df_1_feature_2"].copy()
+        filtered_exceedance_feature_1_df = exceedance_feature_1_df[exceedance_feature_1_df > 0]
+        filtered_exceedance_feature_2_df = exceedance_feature_2_df[exceedance_feature_2_df > 0]
+
+        self.assertEqual(first=filtered_exceedance_feature_1_df.shape[0], second=5)
+        self.assertEqual(first=filtered_exceedance_feature_2_df.shape[0], second=4)
+
+        feature_1_nonzero_params = self.detector._POTDetecto__get_nonzero_params(feature_name="df_1_feature_1")  # type: ignore
+        feature_2_nonzero_params = self.detector._POTDetecto__get_nonzero_params(feature_name="df_1_feature_2")  # type: ignore
+
+        self.assertIsNotNone(obj=feature_1_nonzero_params)
+        self.assertIsNotNone(obj=feature_2_nonzero_params)
+
+        kstest_feature_1_result = ks_1samp(
+            x=filtered_exceedance_feature_1_df,
+            cdf=genpareto.cdf,
+            args=(
+                feature_1_nonzero_params[-1][1][0],
+                feature_1_nonzero_params[-1][1][1],
+                feature_1_nonzero_params[-1][1][2],
+            ),
+        )
+
+        kstest_feature_2_result = ks_1samp(
+            x=filtered_exceedance_feature_2_df,
+            cdf=genpareto.cdf,
+            args=(
+                feature_2_nonzero_params[-1][1][0],
+                feature_2_nonzero_params[-1][1][1],
+                feature_2_nonzero_params[-1][1][2],
+            ),
+        )
+
+        self.assertEqual(first=kstest_feature_1_result.statistic, second=0.3999983048907735)
+        self.assertEqual(first=kstest_feature_1_result.pvalue, second=0.30880444800752727)
+        self.assertEqual(first=kstest_feature_2_result.statistic, second=0.25)
+        self.assertEqual(first=kstest_feature_2_result.pvalue, second=0.90625)
 
     def test_fit_method_catches_value_error(self):
         self.detector.compute_exceedance_threshold(dataset=self.df_1, q=0.90)
@@ -1051,8 +1091,441 @@ class TestPOTDetecto(TestCase):
         with self.assertRaises(expected_exception=ValueError):
             self.detector.detect()
 
-    def test_evaluate_method(self):
-        pass
+    def test_evaluate_method_with_kolmogorov_smirnof(self):
+        test_df = DataFrame(
+            data={
+                "df_1_feature_1": [
+                    263,
+                    275,
+                    56,
+                    308,
+                    488,
+                    211,
+                    70,
+                    42,
+                    67,
+                    472,
+                    304,
+                    297,
+                    480,
+                    227,
+                    453,
+                    342,
+                    115,
+                    115,
+                    67,
+                    295,
+                    9,
+                    228,
+                    89,
+                    225,
+                    360,
+                    367,
+                    418,
+                    124,
+                    229,
+                    12,
+                    111,
+                    341,
+                    209,
+                    374,
+                    254,
+                    322,
+                    99,
+                    166,
+                    435,
+                    481,
+                    106,
+                    438,
+                    180,
+                    33,
+                    30,
+                    330,
+                    139,
+                    17,
+                    268,
+                    204000,
+                ],
+                "df_1_feature_2": [
+                    387,
+                    525,
+                    520,
+                    79,
+                    345000,
+                    474,
+                    336,
+                    159,
+                    164,
+                    110,
+                    308,
+                    434,
+                    197,
+                    470,
+                    411,
+                    100,
+                    33,
+                    205,
+                    229,
+                    295,
+                    599,
+                    535,
+                    364,
+                    24,
+                    476,
+                    582,
+                    7,
+                    418,
+                    33,
+                    149,
+                    303,
+                    11,
+                    359,
+                    484,
+                    339,
+                    69,
+                    267,
+                    297,
+                    19,
+                    69,
+                    56,
+                    533,
+                    225,
+                    524,
+                    596,
+                    304,
+                    181,
+                    535,
+                    369,
+                    351,
+                ],
+            }
+        )
+        self.detector.timeframe.set_interval(total_rows=test_df.shape[0])
+        expected_exceedance_threshold_df = DataFrame(
+            data={
+                "df_1_feature_1": [
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    454.90000000000003,
+                    453.0,
+                    449.50000000000006,
+                    446.0,
+                    442.5,
+                    439.00000000000006,
+                    435.5,
+                    431.99999999999994,
+                    428.50000000000017,
+                    438.6,
+                    454.90000000000003,
+                    453.0,
+                    451.5,
+                    450.00000000000006,
+                    448.50000000000006,
+                    447.0,
+                    445.5,
+                    444.0,
+                    442.50000000000006,
+                    441.00000000000006,
+                    454.90000000000003,
+                ],
+                "df_1_feature_2": [
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    539.7,
+                    535.0,
+                    534.0,
+                    533.0,
+                    532.0,
+                    531.0,
+                    530.0,
+                    529.0,
+                    528.0,
+                    527.0,
+                    526.0,
+                    525.0,
+                    532.2,
+                    531.4000000000001,
+                    530.6,
+                    534.2,
+                    534.0,
+                    533.8,
+                    535.0,
+                    535.0,
+                    535.0,
+                ],
+            }
+        )
+        expected_exceedance_df = DataFrame(
+            data={
+                "df_1_feature_1": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    33.099999999999966,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    17.099999999999966,
+                    0.0,
+                    0.0,
+                    25.099999999999966,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    26.099999999999966,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    203545.1,
+                ],
+                "df_1_feature_2": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    344460.3,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    59.299999999999955,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    42.299999999999955,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.7999999999999545,
+                    0.0,
+                    0.0,
+                    61.799999999999955,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
+            }
+        )
+        expected_anomaly_score_df = DataFrame(
+            data={
+                "anomaly_score_df_1_feature_1": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.5947881128257808,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    float("inf"),
+                ],
+                "anomaly_score_df_1_feature_2": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0092577188337257,
+                    0.0,
+                    0.0,
+                    2.1563458584349675,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
+                "total_anomaly_score": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.5947881128257808,
+                    0.0,
+                    1.0092577188337257,
+                    0.0,
+                    0.0,
+                    2.1563458584349675,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    float("inf"),
+                ],
+            }
+        )
+        self.detector.compute_exceedance_threshold(dataset=test_df, q=0.90)
+
+        pd_testing.assert_frame_equal(
+            left=self.detector.exceedance_threshold_dataset, right=expected_exceedance_threshold_df
+        )
+
+        self.detector.extract_exceedance(
+            dataset=test_df,
+            fill_value=0.0,
+            clip_lower=0.0,
+        )
+
+        pd_testing.assert_frame_equal(left=self.detector.exceedance_dataset, right=expected_exceedance_df)
+
+        self.detector.fit(dataset=test_df)
+
+        pd_testing.assert_frame_equal(left=self.detector.anomaly_score_dataset, right=expected_anomaly_score_df)
+
+        self.detector.evaluate(method="ks", stat_distance_threshold=0.5)
+
+        expected_kstest_result = DataFrame(
+            data={
+                "feature": ["df_1_feature_1", "df_1_feature_2"],
+                "total_exceedances": [5, 5],
+                "stat_distance": [0.4, 0.3015702053031097],
+                "p_value": [0.3087999999999995, 0.6578151672671728],
+                "c": [-3.507231273303336, 5.13336319598767],
+                "loc": [0, 0],
+                "scale": [116.08935514634031, 6.263007768565435],
+                "is_identical": [True, True],
+            }
+        )
+
+        pd_testing.assert_frame_equal(left=self.detector.kstest_result, right=expected_kstest_result)
+
+        self.detector.evaluate(method="ks", stat_distance_threshold=0.3)
+        expected_kstest_result["is_identical"] = [False, False]
+
+        pd_testing.assert_frame_equal(left=self.detector.kstest_result, right=expected_kstest_result)
 
     def test_params_attributes(self):
         expected_params = {

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -1091,7 +1091,28 @@ class TestPOTDetecto(TestCase):
         with self.assertRaises(expected_exception=ValueError):
             self.detector.detect()
 
-    def test_evaluate_method_with_kolmogorov_smirnof(self):
+    def test_get_nonzero_params_method_catches_value_error(self):
+        detector = POTDetecto()
+
+        with self.assertRaises(expected_exception=ValueError):
+            detector._POTDetecto__get_nonzero_params(feature_name="feature_1")  # type: ignore
+
+        detector.timeframe.set_interval(total_rows=1000)
+
+        with self.assertRaises(expected_exception=ValueError):
+            detector._POTDetecto__get_nonzero_params(feature_name="feature_1")  # type: ignore
+
+    def test_ks_1sample_method_catches_value_error(self):
+        with self.assertRaises(expected_exception=ValueError):
+            self.detector._POTDetecto__ks_1sample(  # type: ignore
+                nonzero_exceedance_dataset=[[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], stat_distance_threshold=0.03
+            )
+
+    def test_ks_evaluate_method_catches_value_error(self):
+        with self.assertRaises(expected_exception=ValueError):
+            self.detector.evaluate(method="ks", stat_distance_threshold=0.05)
+
+    def test_evaluate_method_with_ks(self):
         test_df = DataFrame(
             data={
                 "df_1_feature_1": [

--- a/tests/unit_tests/detectors/test_pot_detecto.py
+++ b/tests/unit_tests/detectors/test_pot_detecto.py
@@ -605,8 +605,6 @@ class TestPOTDetecto(TestCase):
             data={
                 "is_anomaly": [
                     False,
-                    True,
-                    False,
                     False,
                     False,
                     False,

--- a/tests/unit_tests/timeframes/test_pot_timeframe.py
+++ b/tests/unit_tests/timeframes/test_pot_timeframe.py
@@ -24,8 +24,8 @@ class TestPOTDetecto(TestCase):
         self.timeframe.set_interval(total_rows=10000)
 
         self.assertEqual(first=self.timeframe.t0, second=6000)
-        self.assertEqual(first=self.timeframe.t1, second=2500)
-        self.assertEqual(first=self.timeframe.t2, second=1500)
+        self.assertEqual(first=self.timeframe.t1, second=3000)
+        self.assertEqual(first=self.timeframe.t2, second=1000)
 
     def test_pot_detecto_set_time_windows_method_prod_mode(self):
         self.timeframe.set_interval(total_rows=10000, prod_mode=True)


### PR DESCRIPTION
- [X] Create a wrapper method for `scipy.stats.ks_1samp()` to give users a way to evaluate the result of the `scipy.stats.genpareto.fit()` result (params). The `h0` of Kolmogorov Smirnov test is that 2 distributions are identical `F(x) == G(x)`. Users can now run `evaluate(method="ks", stat_distance_threshold=0.05)` to observe whether the fitting method runs perfectly. The observation can be seen in `kstest_result` attribute in `POTDetecto` that shows the statistical distance between the 2 distribution (`exceedance_dataset` and the CDF of last non-zero `c`, `loc`, `scale`).
- [X] Create unit tests to test the Kolmogorov Smirnov test result and the `evaluate()` method.
- [X] Complete the docstring documentation of the class `POTDetecto`.

closes #14 